### PR TITLE
Add support for non-zip zarr archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MATS-l1b-tools
 Repository to hold tools for manipulating, plotting and analyzing MATS L1b dataset. 
-For assistance and discussiond please consider joining our MATS discord community
+For assistance and discussion please consider joining our MATS discord community
 https://discord.com/channels/1197482909997727774/1197482911763533836
 
 
@@ -18,6 +18,7 @@ The address should be the web address of the zarr archive to be read. Must be pr
 | Option    | Description |
 | --------- | ----------- |                       
 |-h or --help                           | Show short help info and exit |
+|-c or --channel                        | Data channel to download.<br>Can be IR1, IR2, IR3, IR4, UV1, UV2. |
 |-b or --start_time YYYY MM DD hh mm ss | Start time for data set |
 |-e or --stop_time YYYY MM DD hh mm ss  | Stop time for data set |
 |-f or --filter [variable] [lower bound] [upper bound] | Filter data set by values of given variable |
@@ -25,8 +26,18 @@ The address should be the web address of the zarr archive to be read. Must be pr
 |-z or --zarr_out [filename]            | Generate output as zarr file with given name |
 |-t or --tp_coords                      | Interpolate tangent point coordinates for every pixel |
 
-Note that filtering can only be used with variables that have one value per image. Trying to use it with more complex variables would return an error.
+Note that filtering can only be used with variables that have one value per image. Trying to use it with more complex variables would return an error. 
+If neither zarr nor netCDF output is specified, netCDF file with a default name will be created.
+
+By default, the latest data version on the Bolin centre server (https://bolin.su.se/data/s3/) will be used. The following options can be added to use a different zarr archive and/or a different server:
+
+| Advanced option   | Description |
+| ---------         | ----------- |  
+|-u or --url        | Use non-default server with the specified URL. |
+|-p or --path_base  | Specify non-default file path on the server (without channel name) |
+|-P or --path_full  | Specify non-default full file path on the server (overrides path_base) |
+|-a or --address    | Explicitly specify full address of zarr archive (overrides all of the above) |
 
 An example command for running get_zarr.py:
 
-    python get_zarr.py zip::https://bolin.su.se/data/s3/data/mats-level-1b-limb-cropd-1.0-root/mats-level-1b-limb-cropd-UV2.zarr.zip -b 2023 2 20 0 0 0 -e 2023 3 1 0 0 0  -f TPlon 10 30
+    python get_zarr.py -c IR1 -b 2023 2 20 0 0 0 -e 2023 3 1 0 0 0  -f TPlon 10 30

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@ fsspec
 netCDF4
 numpy
 requests
+s3fs
+scipy
 xarray
 zarr<3.0
 zipp
-scipy


### PR DESCRIPTION
Updated download script, documentation and requirements.txt . The address of Bolin server and MATS dataset on it are now included in the download script (they can be overridden using command line options, if needed). By default, one only needs to specify the channel to download.